### PR TITLE
Minor style tweaks

### DIFF
--- a/src/components/Repositories.module.css
+++ b/src/components/Repositories.module.css
@@ -33,6 +33,18 @@ limitations under the License.
     align-items: center;
 }
 
+@media (max-width: 996px) {
+    :global(.row) .repository:global(.col.col--4) {
+        --ifm-col-width: 50%;
+    }
+}
+
+@media (max-width: 600px) {
+    :global(.row) .repository:global(.col.col--4) {
+        --ifm-col-width: 100%;
+    }
+}
+
 .repositoryImage {
     height: 130px;
     width: 200px;
@@ -54,6 +66,8 @@ limitations under the License.
 
 .repositoryDescription {
     text-align: center;
+    padding-left: 10%;
+    padding-right: 10%;
 }
 
 .exploreMore {

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -42,5 +42,5 @@ limitations under the License.
 }
 
 .heroSubtitle {
-  font-size: 1.5rem;
+  font-size: 2rem;
 }


### PR DESCRIPTION
### :pencil: Description

* Updated hero banner's subtitle to have the same size as the title
* Added some left/right padding on repository's description to keep more distance between adjacent repositories
* More responsive number of columns (1, 2 or 3):
   * Before this pull request: 0-996px ➔ 1 column, >996px ➔ 3 columns
   * After this pull request: 0-600px ➔ 1 column, 600-996px ➔ 2 columns, >996px ➔ 3 columns
