### PR TITLE
Fix Github Action build loop

### DIFF
--- a/.github/workflows/cname-check.yml
+++ b/.github/workflows/cname-check.yml
@@ -1,8 +1,6 @@
 name: cname check
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/release-gh-pages.yml
+++ b/.github/workflows/release-gh-pages.yml
@@ -1,11 +1,11 @@
 name: Build and release site to GitHub Pages
 
 on:
-  push:
-    branches: [main]
   schedule:
     # daily build
     - cron:  '0 0 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   gh-pages-release:


### PR DESCRIPTION
### :pencil: Description

Automated commits from eg-oss-ci during the build, trigger new builds in an endless loop.
In the past this was not a problem because the build checks for git diffs before committing, but now it seems that there is always a change in the repo image url.

For now, to break this loop I'm removing the workflow trigger on main branch commit.
I'm keeping the scheduled build that runs daily.

### :framed_picture: Screenshot



### :link: Related Issues

