### PR TITLE
Add Jest coverage threshold and update test scripts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
@@ -7,32 +8,46 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 You should update the version number in the [package.json](./package.json) according to the semantic versioning,
 then run `npm install`.
 
+## 1.6.1
+
+- Added coverage threshold for automated tests.
+
 ## 1.6.0
+
 - Added 3D hero banner
 
 ## 1.5.1
+
 - Bumped to node 16, docusaurus 2.0.1, react 17.0.2
 
 ## 1.5.0
+
 - Fetch list of repositories by topic with GitHub GraphQL API instead of hardcoded list.
 
 ## 1.4.0
+
 - Added pagination to Repositories Page.
 
 ## 1.3.0
+
 - Added Repositories Page.
 
 ## 1.2.3
+
 - Added snapshot unit tests for all React components.
 
 ## 1.2.2
+
 - Refactored and added unit tests for `build-posts-data.js`.
 
 ## 1.2.1
+
 - Refactored and added unit tests for `build-repo-data.js`.
 
 ## 1.2.0
+
 - Added image to Medium blog posts, parsing the `content:encoded` field of the RSS feed.
 
 ## 1.1.0
+
 - Switched source of Medium blog posts from Pixel Point widget to RSS feed. It shows: title, link, creator, date.

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,7 +21,23 @@ const config = {
         "\\.[jt]sx?$": "babel-jest",
         ".+\\.(css|styl|less|sass|scss)$": "jest-css-modules-transform"
     },
-    transformIgnorePatterns: ["/node_modules/(?!(@babel/runtime)/)"]
+    transformIgnorePatterns: ["/node_modules/(?!(@babel/runtime)/)"],
+
+    collectCoverage: true,
+    coverageThreshold: {
+        global: {
+            branches: 80,
+            functions: 80,
+            lines: 80,
+            statements: 80
+        }
+    },
+    collectCoverageFrom: [
+        "src/**/*.{js,jsx,ts,tsx}", 
+        "!src/**/*.test.{js,jsx,ts,tsx}",
+        "!src/**/__tests__/**" 
+    ],
+    coverageDirectory: "./coverage"
 };
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "deploy": "docusaurus deploy",
     "serve": "docusaurus serve",
     "clear": "docusaurus clear",
-    "test": "jest"
+    "test": "jest --coverage"
   },
   "dependencies": {
     "@apollo/client": "^3.5.8",


### PR DESCRIPTION
### :pencil: Description
**This PR introduces coverage thresholds for Jest tests to enforce minimum code coverage.**

### Fixes #45 

### :framed_picture: Screenshot
![Screenshot (25)](https://github.com/user-attachments/assets/1ac35e3a-5a19-42e7-913b-93dccc804142)

### List the major changes in this PR.
- Added coverageThreshold configuration in jest.config.js.
- Enabled coverage collection with collectCoverage.
- Updated test script in package.json to run Jest with coverage.
- Verified that the coverage report is generated by running npm run test.
- Mentioned the changes that are made in CONTRIBUTING.md.

